### PR TITLE
Fix minor syntax issue

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -31,7 +31,7 @@ curl --silent --location https://git-core.googlecode.com/files/git-$GIT_VERSION.
 cd git-$GIT_VERSION
 echo "       done."
 
-if [[ ! -d $BUILD_DIR/bin]]; then
+if [[ ! -d $BUILD_DIR/bin ]]; then
   mkdir $BUILD_DIR/bin
 fi
 


### PR DESCRIPTION
Hello,

Thanks you for sharing your great buildpack, but I faced an issue when pushing on Heroku:

```
-----> Fetching custom git buildpack... done
-----> Multipack app detected
=====> Downloading Buildpack: https://github.com/abhishekmunie/heroku-buildpack-git.git
=====> Detected Framework: Static
-----> Downloading Git 1.8.1.4...        done.
/tmp/buildpack2dxCF/bin/compile: line 34: syntax error in conditional expression: unexpected token `;'
 !     Heroku push rejected, failed to compile Multipack app
```

You just forgot a space :)
