### PR TITLE
Caching and optimised file size of compiled Git binaries

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -31,7 +31,7 @@ curl --silent --location https://git-core.googlecode.com/files/git-$GIT_VERSION.
 cd git-$GIT_VERSION
 echo "       done."
 
-if [[ ! -d $BUILD_DIR/bin]]; then
+if [[ ! -d $BUILD_DIR/bin ]]; then
   mkdir $BUILD_DIR/bin
 fi
 

--- a/bin/compile
+++ b/bin/compile
@@ -47,7 +47,7 @@ else
   fi
 
   echo -n "-----> Compiling Git..."
-  make NO_TCLTK=YesPlease NO_PERL=YesPlease NO_GETTEXT=YesPlease NO_SVN_TESTS=YesPlease NO_MSGFMT=YesPlease NO_MSGFMT_EXTENDED_OPTIONS=YesPlease prefix=$BIN_DIR install clean | indent
+  make NO_TCLTK=YesPlease NO_PERL=YesPlease NO_GETTEXT=YesPlease NO_SVN_TESTS=YesPlease NO_MSGFMT=YesPlease NO_MSGFMT_EXTENDED_OPTIONS=YesPlease CFLAGS="-Os -g0 -Wall" prefix=$BIN_DIR install clean | indent
   echo "       done."
 
   echo -n "-----> Cleaning up Git source files..."

--- a/bin/compile
+++ b/bin/compile
@@ -27,6 +27,10 @@ fi
 
 BIN_DIR=$BUILD_DIR/vendor/git-$GIT_VERSION
 
+if [[ ! -d "$BIN_DIR" ]]; then
+  mkdir -p "$BIN_DIR"
+fi
+
 if [[ -d "$CACHE_DIR/vendor/git-$GIT_VERSION" ]]; then
   echo -n "-----> Using cached Git $GIT_VERSION..."
   cp -r "$CACHE_DIR/vendor/git-$GIT_VERSION" "$BIN_DIR/"
@@ -41,10 +45,6 @@ else
   curl --silent --location "https://git-core.googlecode.com/files/git-$GIT_VERSION.tar.gz" | tar xz
   cd "git-$GIT_VERSION"
   echo "       done."
-
-  if [[ ! -d "$BIN_DIR" ]]; then
-    mkdir -p "$BIN_DIR"
-  fi
 
   echo -n "-----> Compiling Git..."
   make NO_TCLTK=YesPlease NO_PERL=YesPlease NO_GETTEXT=YesPlease NO_SVN_TESTS=YesPlease NO_MSGFMT=YesPlease NO_MSGFMT_EXTENDED_OPTIONS=YesPlease CFLAGS="-Os -g0 -Wall" prefix="$BIN_DIR" install clean | indent

--- a/bin/compile
+++ b/bin/compile
@@ -28,11 +28,13 @@ fi
 BIN_DIR=$BUILD_DIR/vendor/git-$GIT_VERSION
 
 if test -d $CACHE_DIR/vendor/git-$GIT_VERSION; then
-  echo "-----> Using cached Git $GIT_VERSION..."
+  echo -n "-----> Using cached Git $GIT_VERSION..."
   cp -r $CACHE_DIR/vendor/git-$GIT_$VERSION $BIN_DIR/
+  echo "       done."
 else
   echo -n "-----> Cleaning cached Git versions..."
   rm -rf $CACHE_DIR/vendor/git-*
+  echo "       done."
 
   echo -n "-----> Downloading Git $GIT_VERSION..."
   cd $BUILD_DIR
@@ -44,16 +46,18 @@ else
     mkdir -p $BIN_DIR
   fi
 
-  echo "-----> Compiling Git..."
+  echo -n "-----> Compiling Git..."
   make NO_TCLTK=YesPlease NO_PERL=YesPlease NO_GETTEXT=YesPlease NO_SVN_TESTS=YesPlease NO_MSGFMT=YesPlease NO_MSGFMT_EXTENDED_OPTIONS=YesPlease prefix=$BIN_DIR install clean | indent
   echo "       done."
 
-  echo "-----> Cleaning up Git source files..."
+  echo -n "-----> Cleaning up Git source files..."
   rm -rf $BUILD_DIR/git-$GIT_VERSION
+  echo "       done."
   
-  echo "-----> Caching Git binaries..."
+  echo -n "-----> Caching Git binaries..."
   mkdir -p $CACHE_DIR/vendor/git-$GIT_$VERSION
   cp -r $BIN_DIR $CACHE_DIR/vendor/git-$GIT_$VERSION/
+  echo "       done."
 fi
 
 export PATH=$BIN_DIR:$PATH

--- a/bin/compile
+++ b/bin/compile
@@ -19,7 +19,7 @@ function indent() {
   esac
 }
 
-source $BUILD_DIR/_git.cfg
+source "$BUILD_DIR/_git.cfg"
 
 if [[ ! $GIT_VERSION ]]; then
   GIT_VERSION=1.8.1.4
@@ -27,36 +27,36 @@ fi
 
 BIN_DIR=$BUILD_DIR/vendor/git-$GIT_VERSION
 
-if test -d $CACHE_DIR/vendor/git-$GIT_VERSION; then
+if [[ -d "$CACHE_DIR/vendor/git-$GIT_VERSION" ]]; then
   echo -n "-----> Using cached Git $GIT_VERSION..."
-  cp -r $CACHE_DIR/vendor/git-$GIT_$VERSION $BIN_DIR/
+  cp -r "$CACHE_DIR/vendor/git-$GIT_VERSION" "$BIN_DIR/"
   echo "       done."
 else
   echo -n "-----> Cleaning cached Git versions..."
-  rm -rf $CACHE_DIR/vendor/git-*
+  rm -rf "$CACHE_DIR/vendor/git-*"
   echo "       done."
 
   echo -n "-----> Downloading Git $GIT_VERSION..."
-  cd $BUILD_DIR
-  curl --silent --location https://git-core.googlecode.com/files/git-$GIT_VERSION.tar.gz | tar xz
-  cd git-$GIT_VERSION
+  cd "$BUILD_DIR"
+  curl --silent --location "https://git-core.googlecode.com/files/git-$GIT_VERSION.tar.gz" | tar xz
+  cd "git-$GIT_VERSION"
   echo "       done."
 
-  if [[ ! -d $BIN_DIR ]]; then
-    mkdir -p $BIN_DIR
+  if [[ ! -d "$BIN_DIR" ]]; then
+    mkdir -p "$BIN_DIR"
   fi
 
   echo -n "-----> Compiling Git..."
-  make NO_TCLTK=YesPlease NO_PERL=YesPlease NO_GETTEXT=YesPlease NO_SVN_TESTS=YesPlease NO_MSGFMT=YesPlease NO_MSGFMT_EXTENDED_OPTIONS=YesPlease CFLAGS="-Os -g0 -Wall" prefix=$BIN_DIR install clean | indent
+  make NO_TCLTK=YesPlease NO_PERL=YesPlease NO_GETTEXT=YesPlease NO_SVN_TESTS=YesPlease NO_MSGFMT=YesPlease NO_MSGFMT_EXTENDED_OPTIONS=YesPlease CFLAGS="-Os -g0 -Wall" prefix="$BIN_DIR" install clean | indent
   echo "       done."
 
   echo -n "-----> Cleaning up Git source files..."
-  rm -rf $BUILD_DIR/git-$GIT_VERSION
+  rm -rf "$BUILD_DIR/git-$GIT_VERSION"
   echo "       done."
-  
+
   echo -n "-----> Caching Git binaries..."
-  mkdir -p $CACHE_DIR/vendor/git-$GIT_$VERSION
-  cp -r $BIN_DIR $CACHE_DIR/vendor/git-$GIT_$VERSION/
+  mkdir -p "$CACHE_DIR/vendor"
+  cp -r "$BIN_DIR" "$CACHE_DIR/vendor/"
   echo "       done."
 fi
 

--- a/bin/compile
+++ b/bin/compile
@@ -36,7 +36,7 @@ if [[ ! -d $BUILD_DIR/bin ]]; then
 fi
 
 echo "-----> Installing Git..."
-make NO_TCLTK=YesPlease NO_PERL=YesPlease NO_GETTEXT=YesPlease NO_SVN_TESTS=YesPlease NO_MSGFMT=YesPlease NO_MSGFMT_EXTENDED_OPTIONS=YesPlease prefix=$BUILD_DIR/bin install | indent
+make NO_TCLTK=YesPlease NO_PERL=YesPlease NO_GETTEXT=YesPlease NO_SVN_TESTS=YesPlease NO_MSGFMT=YesPlease NO_MSGFMT_EXTENDED_OPTIONS=YesPlease prefix=$BUILD_DIR/bin install clean | indent
 echo "       done."
 
 export PATH=$BUILD_DIR/bin:$PATH

--- a/bin/compile
+++ b/bin/compile
@@ -25,18 +25,35 @@ if [[ ! $GIT_VERSION ]]; then
   GIT_VERSION=1.8.1.4
 fi
 
-cd $BUILD_DIR
-echo -n "-----> Downloading Git $GIT_VERSION... "
-curl --silent --location https://git-core.googlecode.com/files/git-$GIT_VERSION.tar.gz | tar xz
-cd git-$GIT_VERSION
-echo "       done."
+BIN_DIR=$BUILD_DIR/vendor/git-$GIT_VERSION
 
-if [[ ! -d $BUILD_DIR/bin ]]; then
-  mkdir $BUILD_DIR/bin
+if test -d $CACHE_DIR/vendor/git-$GIT_VERSION; then
+  echo "-----> Using cached Git $GIT_VERSION..."
+  cp -r $CACHE_DIR/vendor/git-$GIT_$VERSION $BIN_DIR/
+else
+  echo -n "-----> Cleaning cached Git versions..."
+  rm -rf $CACHE_DIR/vendor/git-*
+
+  echo -n "-----> Downloading Git $GIT_VERSION..."
+  cd $BUILD_DIR
+  curl --silent --location https://git-core.googlecode.com/files/git-$GIT_VERSION.tar.gz | tar xz
+  cd git-$GIT_VERSION
+  echo "       done."
+
+  if [[ ! -d $BIN_DIR ]]; then
+    mkdir -p $BIN_DIR
+  fi
+
+  echo "-----> Compiling Git..."
+  make NO_TCLTK=YesPlease NO_PERL=YesPlease NO_GETTEXT=YesPlease NO_SVN_TESTS=YesPlease NO_MSGFMT=YesPlease NO_MSGFMT_EXTENDED_OPTIONS=YesPlease prefix=$BIN_DIR install clean | indent
+  echo "       done."
+
+  echo "-----> Cleaning up Git source files..."
+  rm -rf $BUILD_DIR/git-$GIT_VERSION
+  
+  echo "-----> Caching Git binaries..."
+  mkdir -p $CACHE_DIR/vendor/git-$GIT_$VERSION
+  cp -r $BIN_DIR $CACHE_DIR/vendor/git-$GIT_$VERSION/
 fi
 
-echo "-----> Installing Git..."
-make NO_TCLTK=YesPlease NO_PERL=YesPlease NO_GETTEXT=YesPlease NO_SVN_TESTS=YesPlease NO_MSGFMT=YesPlease NO_MSGFMT_EXTENDED_OPTIONS=YesPlease prefix=$BUILD_DIR/bin install clean | indent
-echo "       done."
-
-export PATH=$BUILD_DIR/bin:$PATH
+export PATH=$BIN_DIR:$PATH


### PR DESCRIPTION
Uses the Heroku slug compiler's cache directory to **drastically** reduce repeated build times.

Also generates binaries that are much smaller so the compressed slug size limit is not broken.
