### PR TITLE
Add other git binaries to PATH

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -92,4 +92,4 @@ fi
 # Update the PATH
 status "Building runtime environment"
 mkdir -p $build_dir/.profile.d
-echo "export PATH=\"\$HOME/vendor/git/bin:\$PATH\";" > $build_dir/.profile.d/git.sh
+echo "export PATH=\"\$HOME/vendor/git/bin:\$HOME/vendor/git/libexec/git-core:\$PATH\";" > $build_dir/.profile.d/git.sh

--- a/bin/release
+++ b/bin/release
@@ -4,5 +4,5 @@
 cat <<EOF
 ---
 config_vars:
-  PATH: vendor/git/bin:bin:/usr/local/bin:/usr/bin:/bin
+  PATH: vendor/git/bin:vendor/git/libexec/git-core:bin:/usr/local/bin:/usr/bin:/bin
 EOF


### PR DESCRIPTION
Some executables, e.g. git submodule, are not on PATH in the current version. This patch adds them to the PATH.

I'm not sure whether this is the right way to go, but it resolved my problem.
